### PR TITLE
Fix ltrace source download

### DIFF
--- a/package/ltrace/ltrace.mk
+++ b/package/ltrace/ltrace.mk
@@ -5,7 +5,7 @@
 #############################################################
 
 LTRACE_VERSION = 0.7.2
-LTRACE_SITE = http://alioth.debian.org/frs/download.php/3848
+LTRACE_SITE = https://alioth.debian.org/plugins/scmgit/cgi-bin/gitweb.cgi?p=ltrace/ltrace.git;a=snapshot;h=d66c8b11facf570d96a49c1b812b90101c62023b;sf=tgz
 LTRACE_SOURCE = ltrace-$(LTRACE_VERSION).tar.bz2
 LTRACE_DEPENDENCIES = libelf
 LTRACE_AUTORECONF = YES


### PR DESCRIPTION
ltrace source tarball is not available to an anonymous user anymore at 
https://alioth.debian.org/frs/download.php/file/3848/ltrace-0.7.2.tar.bz2

Lets download snapshot from GIT
