### PR TITLE
[PKG][OPENSSH] Create /var/empty whenever sshd is start

### DIFF
--- a/package/openssh/S50sshd
+++ b/package/openssh/S50sshd
@@ -38,6 +38,9 @@ umask 077
 
 start() {
  	echo -n "Starting sshd: "
+	mkdir -p /var/empty
+	chown root:sys /var/empty
+	chmod 750 /var/empty
 	/usr/sbin/sshd
 	touch /var/lock/sshd
 	echo "OK"


### PR DESCRIPTION
openssh requires special folder /var/empty
/var/empty must be owned by root and not group or world-writable
