### PR TITLE
Fix 'screen' package creation

### DIFF
--- a/package/screen/screen-install-fix.patch
+++ b/package/screen/screen-install-fix.patch
@@ -1,7 +1,7 @@
 diff -ru screen-4.0.2_vanilla/Makefile.in screen-4.0.2_install-fixup/Makefile.in
 --- screen-4.0.2_vanilla/Makefile.in	2003-12-05 13:59:39.000000000 +0000
 +++ screen-4.0.2_install-fixup/Makefile.in	2009-01-03 15:20:22.000000000 +0000
-@@ -71,14 +71,9 @@
+@@ -71,14 +71,10 @@
  	$(CC) -c -I. -I$(srcdir) $(M_CFLAGS) $(DEFS) $(OPTIONS) $(CFLAGS) $<
  
  install_bin: .version screen
@@ -13,6 +13,7 @@ diff -ru screen-4.0.2_vanilla/Makefile.in screen-4.0.2_install-fixup/Makefile.in
 -	-if [ -f $(DESTDIR)$(bindir)/screen ] && [ ! -f $(DESTDIR)$(bindir)/screen.old ]; then mv $(DESTDIR)$(bindir)/screen $(DESTDIR)$(bindir)/screen.old; fi
 -	rm -f $(DESTDIR)$(bindir)/screen
 -	(cd $(DESTDIR)$(bindir) && ln -sf $(SCREEN) screen)
++	$(INSTALL_PROGRAM) -d $(DESTDIR)$(bindir)
 +	$(INSTALL_PROGRAM) screen $(DESTDIR)$(bindir)/screen
 +	-chmod 4755 $(DESTDIR)$(bindir)/screen
 +	mkdir -p $(DESTDIR)$(SCREENENCODINGS)


### PR DESCRIPTION
Upstream Makefile does not create /usr/bin so 'install screen'
fails when screen binary is installed into temporary package folder.

This change update bundled patch with 'install -d <bindir>'
