### PR TITLE
[skeleton] Add /boot entry into /etc/fstab

### DIFF
--- a/system/skeleton/etc/fstab
+++ b/system/skeleton/etc/fstab
@@ -7,3 +7,4 @@ devpts		/dev/pts       devpts   defaults,gid=5,mode=620	  0	 0
 tmpfs           /dev/shm       tmpfs    mode=0777         0      0
 tmpfs           /tmp           tmpfs    defaults          0      0
 sysfs		/sys	       sysfs    defaults	  0	 0
+/dev/mmcblk0p1	/boot	vfat rw,noauto 0  0


### PR DESCRIPTION
Let's add a /boot entry in fstab file in order to mount in one command
'mount /boot'.

It whould be usefull to edit uEnv.txt on v2r w/o using a Big Brother
(PC)

The entry is marked as noauto in order to avoid the partition damage in
case of power loss.