### PR TITLE
Fix libgphoto2 build

### DIFF
--- a/package/libgphoto2/libgphoto2.mk
+++ b/package/libgphoto2/libgphoto2.mk
@@ -10,7 +10,7 @@ LIBGPHOTO2_SITE = http://optimate.dl.sourceforge.net/project/gphoto/libgphoto/2.
 LIBGPHOTO2_INSTALL_STAGING = YES
 LIBGPHOTO2_INSTALL_TARGET = YES
 LIBGPHOTO2_CONF_OPT = --enable-static
-LIBGPHOTO2_DEPENDENCIES = libusb-compat libtool
+LIBGPHOTO2_DEPENDENCIES = libusb-compat libtool libxml2
 
 
 $(eval $(autotools-package))


### PR DESCRIPTION
libgphoto2 uses unconditionally xml2 but it is not listed in build
dependencies so fsbuild (from scratch) is failed