### PR TITLE
Fix buildeps for virt2real packages (rcboard and rtsp-server)

### DIFF
--- a/package/virt2real/rcboard/rcboard.mk
+++ b/package/virt2real/rcboard/rcboard.mk
@@ -6,6 +6,7 @@
 
 RCBOARD_VERSION = HEAD
 RCBOARD_SITE = http://github.com/virt2real/rcboard/tarball/$(RCBOARD_VERSION)
+RCBOARD_DEPENDENCIES = libconfuse libcurl
 
 define RCBOARD_BUILD_CMDS
         $(MAKE) -C $(@D)/board CC="$(TARGET_CC) $(TARGET_CFLAGS)"

--- a/package/virt2real/rtsp-server/rtsp-server.mk
+++ b/package/virt2real/rtsp-server/rtsp-server.mk
@@ -6,6 +6,7 @@
 
 RTSP_SERVER_VERSION = HEAD
 RTSP_SERVER_SITE = http://github.com/virt2real/othersoft/tarball/$(RTSP_SERVER_VERSION)
+RTSP_SERVER_DEPENDENCIES = gst-rtsp-server
 
 define RTSP_SERVER_BUILD_CMDS
         $(MAKE) -C $(@D)/rtsp-server CC="$(TARGET_CC) $(TARGET_CFLAGS)"


### PR DESCRIPTION
rcboard and rtsp-server has no build deps specified so they may fail
while building from scratch

Steps to check if build fails:

0. go to SDK folder
1. remove fs/output folder to trigger a build from scratch
2. run fresh build of rcboard  and rtsp-server with command:

   make ARCH=arm CSPATH=<path_to/codesourcery/arm-2013.05> \
	--directory fs \
	toolchain rcboard rtsp-serve